### PR TITLE
Create profile from heif_color_profile_nclx struct, not pointer to pointer

### DIFF
--- a/libheif/heif.h
+++ b/libheif/heif.h
@@ -18,6 +18,7 @@
  * along with libheif.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
 #ifndef LIBHEIF_HEIF_H
 #define LIBHEIF_HEIF_H
 
@@ -39,56 +40,60 @@ extern "C" {
 //  1.1          1             1           N/A           N/A            1           N/A
 //  1.3          1             1            1             1             1           N/A
 //  1.4          1             1            1             1             1            1
-//  1.7          1             2            1             1             1            1
-//  1.9.2        1             2            2             1             1            1
-//  1.10         1             2            3             1             1            1
-//  1.11         1             2            4             1             1            1
 
 
 #if defined(_MSC_VER) && !defined(LIBHEIF_STATIC_BUILD)
-#ifdef LIBHEIF_EXPORTS
-#define LIBHEIF_API __declspec(dllexport)
-#else
-#define LIBHEIF_API __declspec(dllimport)
-#endif
+  #ifdef LIBHEIF_EXPORTS
+  #define LIBHEIF_API __declspec(dllexport)
+  #else
+  #define LIBHEIF_API __declspec(dllimport)
+  #endif
 #elif defined(HAVE_VISIBILITY) && HAVE_VISIBILITY
-#ifdef LIBHEIF_EXPORTS
-#define LIBHEIF_API __attribute__((__visibility__("default")))
+  #ifdef LIBHEIF_EXPORTS
+  #define LIBHEIF_API __attribute__((__visibility__("default")))
+  #else
+  #define LIBHEIF_API
+  #endif
 #else
-#define LIBHEIF_API
-#endif
-#else
-#define LIBHEIF_API
+  #define LIBHEIF_API
 #endif
 
-#define heif_fourcc(a, b, c, d) ((a<<24) | (b<<16) | (c<<8) | d)
-
+#define heif_fourcc(a,b,c,d) ((a<<24) | (b<<16) | (c<<8) | d)
+*/
 
 /* === version numbers === */
 
 // Version string of linked libheif library.
-LIBHEIF_API const char* heif_get_version(void);
+//LIBHEIF_API 
+const char *heif_get_version(void);
+
 // Numeric version of linked libheif library, encoded as 0xHHMMLL00 = HH.MM.LL.
-LIBHEIF_API uint32_t heif_get_version_number(void);
+//LIBHEIF_API 
+uint32_t heif_get_version_number(void);
 
 // Numeric part "HH" from above.
-LIBHEIF_API int heif_get_version_number_major(void);
+//LIBHEIF_API 
+int heif_get_version_number_major(void);
+
 // Numeric part "MM" from above.
-LIBHEIF_API int heif_get_version_number_minor(void);
+//LIBHEIF_API 
+int heif_get_version_number_minor(void);
+
 // Numeric part "LL" from above.
-LIBHEIF_API int heif_get_version_number_maintenance(void);
+//LIBHEIF_API 
+int heif_get_version_number_maintenance(void);
 
 // Helper macros to check for given versions of libheif at compile time.
+/*
 #define LIBHEIF_MAKE_VERSION(h, m, l) ((h) << 24 | (m) << 16 | (l) << 8)
 #define LIBHEIF_HAVE_VERSION(h, m, l) (LIBHEIF_NUMERIC_VERSION >= LIBHEIF_MAKE_VERSION(h, m, l))
+*/
 
 struct heif_context;
 struct heif_image_handle;
 struct heif_image;
 
-
-enum heif_error_code
-{
+enum heif_error_code {
   // Everything ok, no error occurred.
   heif_error_Ok = 0,
 
@@ -117,15 +122,11 @@ enum heif_error_code
   heif_error_Encoder_plugin_error = 8,
 
   // Error during encoding or when writing to the output
-  heif_error_Encoding_error = 9,
-
-  // Application has asked for a color profile type that does not exist
-  heif_error_Color_profile_does_not_exist = 10
+  heif_error_Encoding_error = 9
 };
 
 
-enum heif_suberror_code
-{
+enum heif_suberror_code {
   // no further information available
   heif_suberror_Unspecified = 0,
 
@@ -205,7 +206,6 @@ enum heif_suberror_code
 
   heif_suberror_No_av1C_box = 131,
 
-  heif_suberror_Wrong_tile_image_pixel_depth = 132,
 
 
   // --- Memory_allocation_error ---
@@ -267,6 +267,7 @@ enum heif_suberror_code
 };
 
 
+
 struct heif_error
 {
   // main error category
@@ -279,15 +280,11 @@ struct heif_error
   const char* message;
 };
 
-
 typedef uint32_t heif_item_id;
-
-
 
 // ========================= file type check ======================
 
-enum heif_filetype_result
-{
+enum heif_filetype_result {
   heif_filetype_no,
   heif_filetype_yes_supported,   // it is heif and can be read by libheif
   heif_filetype_yes_unsupported, // it is heif, but cannot be read by libheif
@@ -295,13 +292,11 @@ enum heif_filetype_result
 };
 
 // input data should be at least 12 bytes
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_filetype_result heif_check_filetype(const uint8_t* data, int len);
 
 
-// DEPRECATED, use heif_brand2 instead
-enum heif_brand
-{
+enum heif_brand {
   heif_unknown_brand,
   heif_heic, // the usual HEIF images
   heif_heix, // 10bit images, or anything that uses h265 with range extension
@@ -317,41 +312,8 @@ enum heif_brand
 };
 
 // input data should be at least 12 bytes
-// DEPRECATED, use heif_read_main_brand() instead
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_brand heif_main_brand(const uint8_t* data, int len);
-
-
-typedef uint32_t heif_brand2;
-
-// input data should be at least 12 bytes
-LIBHEIF_API
-heif_brand2 heif_read_main_brand(const uint8_t* data, int len);
-
-// 'brand_fourcc' must be 4 character long, but need not be 0-terminated
-LIBHEIF_API
-heif_brand2 heif_fourcc_to_brand(const char* brand_fourcc);
-
-// the output buffer must be at least 4 bytes long
-LIBHEIF_API
-void heif_brand_to_fourcc(heif_brand2 brand, char* out_fourcc);
-
-// 'brand_fourcc' must be 4 character long, but need not be 0-terminated
-// returns 1 if file includes the brand, and 0 if it does not
-// returns -1 if the provided data is not sufficient
-//            (you should input at least as many bytes as indicated in the first 4 bytes of the file, usually ~50 bytes will do)
-// returns -2 on other errors
-LIBHEIF_API
-int heif_has_compatible_brand(const uint8_t* data, int len, const char* brand_fourcc);
-
-// Returns an array of compatible brands. The array is allocated by this function and has to be freed with 'heif_free_list_of_compatible_brands()'.
-// The number of entries is returned in out_size.
-LIBHEIF_API
-struct heif_error heif_list_compatible_brands(const uint8_t* data, int len, heif_brand2** out_brands, int* out_size);
-
-LIBHEIF_API
-void heif_free_list_of_compatible_brands(heif_brand2* brands_list);
-
 
 // Returns one of these MIME types:
 // - image/heic           HEIF file using h265 compression
@@ -367,52 +329,45 @@ void heif_free_list_of_compatible_brands(heif_brand2* brands_list);
 //
 // Note that JPEG and PNG images cannot be decoded by libheif even though the
 // formats are detected by this function.
-LIBHEIF_API
+//LIBHEIF_API
 const char* heif_get_file_mime_type(const uint8_t* data, int len);
-
-
 
 // ========================= heif_context =========================
 // A heif_context represents a HEIF file that has been read.
 // In the future, you will also be able to add pictures to a heif_context
 // and write it into a file again.
 
-
 // Allocate a new context for reading HEIF files.
 // Has to be freed again with heif_context_free().
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_context* heif_context_alloc(void);
 
 // Free a previously allocated HEIF context. You should not free a context twice.
-LIBHEIF_API
+//LIBHEIF_API
 void heif_context_free(struct heif_context*);
-
 
 struct heif_reading_options;
 
-enum heif_reader_grow_status
-{
+enum heif_reader_grow_status {
   heif_reader_grow_status_size_reached,   // requested size has been reached, we can read until this point
   heif_reader_grow_status_timeout,        // size has not been reached yet, but it may still grow further
   heif_reader_grow_status_size_beyond_eof // size has not been reached and never will. The file has grown to its full size
 };
 
-struct heif_reader
-{
+struct heif_reader {
   // API version supported by this reader
   int reader_api_version;
 
   // --- version 1 functions ---
-  int64_t (* get_position)(void* userdata);
+  int64_t (*get_position)(void* userdata);
 
   // The functions read(), and seek() return 0 on success.
   // Generally, libheif will make sure that we do not read past the file size.
-  int (* read)(void* data,
-               size_t size,
-               void* userdata);
-
-  int (* seek)(int64_t position,
-               void* userdata);
+  int (*read)(void* data,
+              size_t size,
+              void* userdata);
+  int (*seek)(int64_t position,
+              void* userdata);
 
   // When calling this function, libheif wants to make sure that it can read the file
   // up to 'target_size'. This is useful when the file is currently downloaded and may
@@ -422,32 +377,31 @@ struct heif_reader
   // Even if your input files will not grow, you will have to implement at least
   // detection whether the target_size is above the (fixed) file length
   // (in this case, return 'size_beyond_eof').
-  enum heif_reader_grow_status (* wait_for_file_size)(int64_t target_size, void* userdata);
+  enum heif_reader_grow_status (*wait_for_file_size)(int64_t target_size, void* userdata);
 };
-
 
 // Read a HEIF file from a named disk file.
 // The heif_reading_options should currently be set to NULL.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_read_from_file(struct heif_context*, const char* filename,
                                               const struct heif_reading_options*);
 
 // Read a HEIF file stored completely in memory.
 // The heif_reading_options should currently be set to NULL.
 // DEPRECATED: use heif_context_read_from_memory_without_copy() instead.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_read_from_memory(struct heif_context*,
                                                 const void* mem, size_t size,
                                                 const struct heif_reading_options*);
 
 // Same as heif_context_read_from_memory() except that the provided memory is not copied.
 // That means, you will have to keep the memory area alive as long as you use the heif_context.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_read_from_memory_without_copy(struct heif_context*,
                                                              const void* mem, size_t size,
                                                              const struct heif_reading_options*);
 
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_read_from_reader(struct heif_context*,
                                                 const struct heif_reader* reader,
                                                 void* userdata,
@@ -456,30 +410,30 @@ struct heif_error heif_context_read_from_reader(struct heif_context*,
 // Number of top-level images in the HEIF file. This does not include the thumbnails or the
 // tile images that are composed to an image grid. You can get access to the thumbnails via
 // the main image handle.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_context_get_number_of_top_level_images(struct heif_context* ctx);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_context_is_top_level_image_ID(struct heif_context* ctx, heif_item_id id);
 
 // Fills in image IDs into the user-supplied int-array 'ID_array', preallocated with 'count' entries.
 // Function returns the total number of IDs filled into the array.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_context_get_list_of_top_level_image_IDs(struct heif_context* ctx,
                                                  heif_item_id* ID_array,
                                                  int count);
 
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_get_primary_image_ID(struct heif_context* ctx, heif_item_id* id);
 
 // Get a handle to the primary image of the HEIF file.
 // This is the image that should be displayed primarily when there are several images in the file.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_get_primary_image_handle(struct heif_context* ctx,
                                                         struct heif_image_handle**);
 
 // Get the handle for a specific top-level image from an image ID.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_context_get_image_handle(struct heif_context* ctx,
                                                 heif_item_id id,
                                                 struct heif_image_handle**);
@@ -487,11 +441,10 @@ struct heif_error heif_context_get_image_handle(struct heif_context* ctx,
 // Print information about the boxes of a HEIF file to file descriptor.
 // This is for debugging and informational purposes only. You should not rely on
 // the output having a specific format. At best, you should not use this at all.
-LIBHEIF_API
+//LIBHEIF_API
 void heif_context_debug_dump_boxes_to_file(struct heif_context* ctx, int fd);
 
-
-LIBHEIF_API
+//LIBHEIF_API
 void heif_context_set_maximum_image_size_limit(struct heif_context* ctx, int maximum_width);
 
 
@@ -506,72 +459,65 @@ void heif_context_set_maximum_image_size_limit(struct heif_context* ctx, int max
 // since it is internally ref-counted.
 
 // Release image handle.
-LIBHEIF_API
+//LIBHEIF_API
 void heif_image_handle_release(const struct heif_image_handle*);
 
 // Check whether the given image_handle is the primary image of the file.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_is_primary_image(const struct heif_image_handle* handle);
 
 // Get the resolution of an image.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_width(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_height(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_has_alpha_channel(const struct heif_image_handle*);
 
-LIBHEIF_API
-int heif_image_handle_is_premultiplied_alpha(const struct heif_image_handle*);
-
-// Returns -1 on error, e.g. if this information is not present in the image.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_luma_bits_per_pixel(const struct heif_image_handle*);
 
-// Returns -1 on error, e.g. if this information is not present in the image.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_chroma_bits_per_pixel(const struct heif_image_handle*);
 
 // Get the image width from the 'ispe' box. This is the original image size without
 // any transformations applied to it. Do not use this unless you know exactly what
 // you are doing.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_ispe_width(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_ispe_height(const struct heif_image_handle* handle);
 
 
 // ------------------------- depth images -------------------------
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_has_depth_image(const struct heif_image_handle*);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_number_of_depth_images(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_list_of_depth_image_IDs(const struct heif_image_handle* handle,
                                                   heif_item_id* ids, int count);
 
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_depth_image_handle(const struct heif_image_handle* handle,
                                                            heif_item_id depth_image_id,
                                                            struct heif_image_handle** out_depth_handle);
 
 
-enum heif_depth_representation_type
-{
+enum heif_depth_representation_type {
   heif_depth_representation_type_uniform_inverse_Z = 0,
   heif_depth_representation_type_uniform_disparity = 1,
   heif_depth_representation_type_uniform_Z = 2,
   heif_depth_representation_type_nonuniform_disparity = 3
 };
 
-struct heif_depth_representation_info
-{
+struct heif_depth_representation_info {
   uint8_t version;
 
   // version 1 fields
@@ -596,15 +542,11 @@ struct heif_depth_representation_info
 };
 
 
-LIBHEIF_API
+//LIBHEIF_API
 void heif_depth_representation_info_free(const struct heif_depth_representation_info* info);
 
 // Returns true when there is depth_representation_info available
-// Note 1: depth_image_id is currently unused because we support only one depth channel per image, but
-// you should still provide the correct ID for future compatibility.
-// Note 2: Because of an API bug before v1.11.0, the function also works when 'handle' is the handle of the depth image.
-// However, you should pass the handle of the main image. Please adapt your code if needed.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_depth_image_representation_info(const struct heif_image_handle* handle,
                                                           heif_item_id depth_image_id,
                                                           const struct heif_depth_representation_info** out);
@@ -614,62 +556,31 @@ int heif_image_handle_get_depth_image_representation_info(const struct heif_imag
 // ------------------------- thumbnails -------------------------
 
 // List the number of thumbnails assigned to this image handle. Usually 0 or 1.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_number_of_thumbnails(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_list_of_thumbnail_IDs(const struct heif_image_handle* handle,
                                                 heif_item_id* ids, int count);
 
 // Get the image handle of a thumbnail image.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_thumbnail(const struct heif_image_handle* main_image_handle,
                                                   heif_item_id thumbnail_id,
                                                   struct heif_image_handle** out_thumbnail_handle);
-
-
-// ------------------------- auxiliary images -------------------------
-
-#define LIBHEIF_AUX_IMAGE_FILTER_OMIT_ALPHA (1UL<<1)
-#define LIBHEIF_AUX_IMAGE_FILTER_OMIT_DEPTH (2UL<<1)
-
-// List the number of auxiliary images assigned to this image handle.
-LIBHEIF_API
-int heif_image_handle_get_number_of_auxiliary_images(const struct heif_image_handle* handle,
-                                                     int aux_filter);
-
-LIBHEIF_API
-int heif_image_handle_get_list_of_auxiliary_image_IDs(const struct heif_image_handle* handle,
-                                                      int aux_filter,
-                                                      heif_item_id* ids, int count);
-
-// You are responsible to deallocate the returned buffer with heif_image_handle_free_auxiliary_types().
-LIBHEIF_API
-struct heif_error heif_image_handle_get_auxiliary_type(const struct heif_image_handle* handle,
-                                                       const char** out_type);
-
-LIBHEIF_API
-void heif_image_handle_free_auxiliary_types(const struct heif_image_handle* handle,
-                                            const char** out_type);
-
-// Get the image handle of an auxiliary image.
-LIBHEIF_API
-struct heif_error heif_image_handle_get_auxiliary_image_handle(const struct heif_image_handle* main_image_handle,
-                                                               heif_item_id auxiliary_id,
-                                                               struct heif_image_handle** out_auxiliary_handle);
 
 
 // ------------------------- metadata (Exif / XMP) -------------------------
 
 // How many metadata blocks are attached to an image. Usually, the only metadata is
 // an "Exif" block.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_number_of_metadata_blocks(const struct heif_image_handle* handle,
                                                     const char* type_filter);
 
 // 'type_filter' can be used to get only metadata of specific types, like "Exif".
 // If 'type_filter' is NULL, it will return all types of metadata IDs.
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_handle_get_list_of_metadata_block_IDs(const struct heif_image_handle* handle,
                                                      const char* type_filter,
                                                      heif_item_id* ids, int count);
@@ -678,16 +589,16 @@ int heif_image_handle_get_list_of_metadata_block_IDs(const struct heif_image_han
 // Exif data will have the type string "Exif".
 // This string will be valid until the next call to a libheif function.
 // You do not have to free this string.
-LIBHEIF_API
+//LIBHEIF_API
 const char* heif_image_handle_get_metadata_type(const struct heif_image_handle* handle,
                                                 heif_item_id metadata_id);
 
-LIBHEIF_API
+//LIBHEIF_API
 const char* heif_image_handle_get_metadata_content_type(const struct heif_image_handle* handle,
                                                         heif_item_id metadata_id);
 
 // Get the size of the raw metadata, as stored in the HEIF file.
-LIBHEIF_API
+//LIBHEIF_API
 size_t heif_image_handle_get_metadata_size(const struct heif_image_handle* handle,
                                            heif_item_id metadata_id);
 
@@ -695,55 +606,41 @@ size_t heif_image_handle_get_metadata_size(const struct heif_image_handle* handl
 // The data is returned exactly as stored in the HEIF file.
 // For Exif data, you probably have to skip the first four bytes of the data, since they
 // indicate the offset to the start of the TIFF header of the Exif data.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_metadata(const struct heif_image_handle* handle,
                                                  heif_item_id metadata_id,
                                                  void* out_data);
 
-enum heif_color_profile_type
-{
+/*
+enum heif_color_profile_type {
   heif_color_profile_type_not_present = 0,
-  heif_color_profile_type_nclx = heif_fourcc('n', 'c', 'l', 'x'),
-  heif_color_profile_type_rICC = heif_fourcc('r', 'I', 'C', 'C'),
-  heif_color_profile_type_prof = heif_fourcc('p', 'r', 'o', 'f')
+  heif_color_profile_type_nclx = heif_fourcc('n','c','l','x'),
+  heif_color_profile_type_rICC = heif_fourcc('r','I','C','C'),
+  heif_color_profile_type_prof = heif_fourcc('p','r','o','f')
 };
-
+*/
 
 // Returns 'heif_color_profile_type_not_present' if there is no color profile.
-// If there is an ICC profile and an NCLX profile, the ICC profile is returned.
-// TODO: we need a new API for this function as images can contain both NCLX and ICC at the same time.
-//       However, you can still use heif_image_handle_get_raw_color_profile() and
-//       heif_image_handle_get_nclx_color_profile() to access both profiles.
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_color_profile_type heif_image_handle_get_color_profile_type(const struct heif_image_handle* handle);
 
-LIBHEIF_API
+//LIBHEIF_API
 size_t heif_image_handle_get_raw_color_profile_size(const struct heif_image_handle* handle);
 
-// Returns 'heif_error_Color_profile_does_not_exist' when there is no ICC profile.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_raw_color_profile(const struct heif_image_handle* handle,
                                                           void* out_data);
 
-
-enum heif_color_primaries
-{
+enum heif_color_primaries {
   heif_color_primaries_ITU_R_BT_709_5 = 1, // g=0.3;0.6, b=0.15;0.06, r=0.64;0.33, w=0.3127,0.3290
   heif_color_primaries_unspecified = 2,
   heif_color_primaries_ITU_R_BT_470_6_System_M = 4,
   heif_color_primaries_ITU_R_BT_470_6_System_B_G = 5,
   heif_color_primaries_ITU_R_BT_601_6 = 6,
-  heif_color_primaries_SMPTE_240M = 7,
-  heif_color_primaries_generic_film = 8,
-  heif_color_primaries_ITU_R_BT_2020_2_and_2100_0 = 9,
-  heif_color_primaries_SMPTE_ST_428_1 = 10,
-  heif_color_primaries_SMPTE_RP_431_2 = 11,
-  heif_color_primaries_SMPTE_EG_432_1 = 12,
-  heif_color_primaries_EBU_Tech_3213_E = 22
+  heif_color_primaries_SMPTE_240M = 7
 };
 
-enum heif_transfer_characteristics
-{
+enum heif_transfer_characteristics {
   heif_transfer_characteristic_ITU_R_BT_709_5 = 1,
   heif_transfer_characteristic_unspecified = 2,
   heif_transfer_characteristic_ITU_R_BT_470_6_System_M = 4,
@@ -751,39 +648,24 @@ enum heif_transfer_characteristics
   heif_transfer_characteristic_ITU_R_BT_601_6 = 6,
   heif_transfer_characteristic_SMPTE_240M = 7,
   heif_transfer_characteristic_linear = 8,
-  heif_transfer_characteristic_logarithmic_100 = 9,
-  heif_transfer_characteristic_logarithmic_100_sqrt10 = 10,
   heif_transfer_characteristic_IEC_61966_2_4 = 11,
   heif_transfer_characteristic_ITU_R_BT_1361 = 12,
-  heif_transfer_characteristic_IEC_61966_2_1 = 13,
-  heif_transfer_characteristic_ITU_R_BT_2020_2_10bit = 14,
-  heif_transfer_characteristic_ITU_R_BT_2020_2_12bit = 15,
-  heif_transfer_characteristic_ITU_R_BT_2100_0_PQ = 16,
-  heif_transfer_characteristic_SMPTE_ST_428_1 = 17,
-  heif_transfer_characteristic_ITU_R_BT_2100_0_HLG = 18
+  heif_transfer_characteristic_IEC_61966_2_1 = 13
 };
 
-enum heif_matrix_coefficients
-{
+enum heif_matrix_coefficients {
   heif_matrix_coefficients_RGB_GBR = 0,
-  heif_matrix_coefficients_ITU_R_BT_709_5 = 1,  // TODO: or 709-6 according to h.273
+  heif_matrix_coefficients_ITU_R_BT_709_5 = 1,
   heif_matrix_coefficients_unspecified = 2,
   heif_matrix_coefficients_US_FCC_T47 = 4,
   heif_matrix_coefficients_ITU_R_BT_470_6_System_B_G = 5,
-  heif_matrix_coefficients_ITU_R_BT_601_6 = 6,  // TODO: or 601-7 according to h.273
+  heif_matrix_coefficients_ITU_R_BT_601_6 = 6,
   heif_matrix_coefficients_SMPTE_240M = 7,
-  heif_matrix_coefficients_YCgCo = 8,
-  heif_matrix_coefficients_ITU_R_BT_2020_2_non_constant_luminance = 9,
-  heif_matrix_coefficients_ITU_R_BT_2020_2_constant_luminance = 10,
-  heif_matrix_coefficients_SMPTE_ST_2085 = 11,
-  heif_matrix_coefficients_chromaticity_derived_non_constant_luminance = 12,
-  heif_matrix_coefficients_chromaticity_derived_constant_luminance = 13,
-  heif_matrix_coefficients_ICtCp = 14
+  heif_matrix_coefficients_YCgCo = 8
 };
 
-struct heif_color_profile_nclx
-{
-  // === version 1 fields
+struct heif_color_profile_nclx {
+  // version 1 fields
 
   uint8_t version;
 
@@ -800,37 +682,23 @@ struct heif_color_profile_nclx
   float color_primary_white_x, color_primary_white_y;
 };
 
-// Returns 'heif_error_Color_profile_does_not_exist' when there is no NCLX profile.
-// TODO: This function does currently not return an NCLX profile if it is stored in the image bitstream.
-//       Only NCLX profiles stored as colr boxes are returned. This may change in the future.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_handle_get_nclx_color_profile(const struct heif_image_handle* handle,
                                                            struct heif_color_profile_nclx** out_data);
 
-// Returned color profile has 'version' field set to the maximum allowed.
-// Do not fill values for higher versions as these might be outside the allocated structure size.
-// May return NULL.
-LIBHEIF_API
-struct heif_color_profile_nclx* heif_nclx_color_profile_alloc();
-
-LIBHEIF_API
-void heif_nclx_color_profile_free(struct heif_color_profile_nclx* nclx_profile);
-
-
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_color_profile_type heif_image_get_color_profile_type(const struct heif_image* image);
 
-LIBHEIF_API
+//LIBHEIF_API
 size_t heif_image_get_raw_color_profile_size(const struct heif_image* image);
 
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_get_raw_color_profile(const struct heif_image* image,
                                                    void* out_data);
 
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_get_nclx_color_profile(const struct heif_image* image,
                                                     struct heif_color_profile_nclx** out_data);
-
 
 
 // ========================= heif_image =========================
@@ -838,14 +706,11 @@ struct heif_error heif_image_get_nclx_color_profile(const struct heif_image* ima
 // An heif_image contains a decoded pixel image in various colorspaces, chroma formats,
 // and bit depths.
 
-// Note: when converting images to an interleaved chroma format, the resulting
-// image contains only a single channel of type channel_interleaved with, e.g., 3 bytes per pixel,
+// Note: when converting images to colorspace_RGB/chroma_interleaved_24bit, the resulting
+// image contains only a single channel of type channel_interleaved with 3 bytes per pixel,
 // containing the interleaved R,G,B values.
 
-// Planar RGB images are specified as heif_colorspace_RGB / heif_chroma_444.
-
-enum heif_compression_format
-{
+enum heif_compression_format {
   heif_compression_undefined = 0,
   heif_compression_HEVC = 1,
   heif_compression_AVC = 2,
@@ -853,36 +718,34 @@ enum heif_compression_format
   heif_compression_AV1 = 4
 };
 
-enum heif_chroma
-{
-  heif_chroma_undefined = 99,
-  heif_chroma_monochrome = 0,
-  heif_chroma_420 = 1,
-  heif_chroma_422 = 2,
-  heif_chroma_444 = 3,
-  heif_chroma_interleaved_RGB = 10,
-  heif_chroma_interleaved_RGBA = 11,
-  heif_chroma_interleaved_RRGGBB_BE = 12,
-  heif_chroma_interleaved_RRGGBBAA_BE = 13,
-  heif_chroma_interleaved_RRGGBB_LE = 14,
-  heif_chroma_interleaved_RRGGBBAA_LE = 15
+enum heif_chroma {
+  heif_chroma_undefined=99,
+  heif_chroma_monochrome=0,
+  heif_chroma_420=1,
+  heif_chroma_422=2,
+  heif_chroma_444=3,
+  heif_chroma_interleaved_RGB =10,
+  heif_chroma_interleaved_RGBA=11,
+  heif_chroma_interleaved_RRGGBB_BE  =12,
+  heif_chroma_interleaved_RRGGBBAA_BE=13,
+  heif_chroma_interleaved_RRGGBB_LE  =14,
+  heif_chroma_interleaved_RRGGBBAA_LE=15
 };
 
 // DEPRECATED ENUM NAMES
+/*
 #define heif_chroma_interleaved_24bit  heif_chroma_interleaved_RGB
 #define heif_chroma_interleaved_32bit  heif_chroma_interleaved_RGBA
+*/
 
-
-enum heif_colorspace
-{
-  heif_colorspace_undefined = 99,
-  heif_colorspace_YCbCr = 0,
-  heif_colorspace_RGB = 1,
-  heif_colorspace_monochrome = 2
+enum heif_colorspace {
+  heif_colorspace_undefined=99,
+  heif_colorspace_YCbCr=0,
+  heif_colorspace_RGB  =1,
+  heif_colorspace_monochrome=2
 };
 
-enum heif_channel
-{
+enum heif_channel {
   heif_channel_Y = 0,
   heif_channel_Cb = 1,
   heif_channel_Cr = 2,
@@ -894,12 +757,10 @@ enum heif_channel
 };
 
 
-enum heif_progress_step
-{
+enum heif_progress_step {
   heif_progress_step_total = 0,
   heif_progress_step_load_tile = 1
 };
-
 
 struct heif_decoding_options
 {
@@ -911,12 +772,9 @@ struct heif_decoding_options
   // Default: false (do not ignore).
   uint8_t ignore_transformations;
 
-  void (* start_progress)(enum heif_progress_step step, int max_progress, void* progress_user_data);
-
-  void (* on_progress)(enum heif_progress_step step, int progress, void* progress_user_data);
-
-  void (* end_progress)(enum heif_progress_step step, void* progress_user_data);
-
+  void (*start_progress)(enum heif_progress_step step, int max_progress, void* progress_user_data);
+  void (*on_progress)(enum heif_progress_step step, int progress, void* progress_user_data);
+  void (*end_progress)(enum heif_progress_step step, void* progress_user_data);
   void* progress_user_data;
 
   // version 2 options
@@ -924,14 +782,13 @@ struct heif_decoding_options
   uint8_t convert_hdr_to_8bit;
 };
 
-
 // Allocate decoding options and fill with default values.
 // Note: you should always get the decoding options through this function since the
 // option structure may grow in size in future versions.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_decoding_options* heif_decoding_options_alloc();
 
-LIBHEIF_API
+//LIBHEIF_API
 void heif_decoding_options_free(struct heif_decoding_options*);
 
 // Decode an heif_image_handle into the actual pixel image and also carry out
@@ -941,7 +798,7 @@ void heif_decoding_options_free(struct heif_decoding_options*);
 // respectively, the original colorspace is taken.
 // Decoding options may be NULL. If you want to supply options, always use
 // heif_decoding_options_alloc() to get the structure.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_decode_image(const struct heif_image_handle* in_handle,
                                     struct heif_image** out_img,
                                     enum heif_colorspace colorspace,
@@ -949,33 +806,22 @@ struct heif_error heif_decode_image(const struct heif_image_handle* in_handle,
                                     const struct heif_decoding_options* options);
 
 // Get the colorspace format of the image.
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_colorspace heif_image_get_colorspace(const struct heif_image*);
 
 // Get the chroma format of the image.
-LIBHEIF_API
+//LIBHEIF_API
 enum heif_chroma heif_image_get_chroma_format(const struct heif_image*);
 
 // Get width of the given image channel in pixels. Returns -1 if a non-existing
 // channel was given.
-LIBHEIF_API
-int heif_image_get_width(const struct heif_image*, enum heif_channel channel);
+//LIBHEIF_API
+int heif_image_get_width(const struct heif_image*,enum heif_channel channel);
 
 // Get height of the given image channel in pixels. Returns -1 if a non-existing
 // channel was given.
-LIBHEIF_API
-int heif_image_get_height(const struct heif_image*, enum heif_channel channel);
-
-// Get the width of the main channel (Y in YCbCr, or any in RGB).
-LIBHEIF_API
-int heif_image_get_primary_width(const struct heif_image*);
-
-LIBHEIF_API
-int heif_image_get_primary_height(const struct heif_image*);
-
-LIBHEIF_API
-struct heif_error heif_image_crop(struct heif_image* img,
-                                  int left, int right, int top, int bottom);
+//LIBHEIF_API
+int heif_image_get_height(const struct heif_image*,enum heif_channel channel);
 
 // Get the number of bits per pixel in the given image channel. Returns -1 if
 // a non-existing channel was given.
@@ -983,9 +829,8 @@ struct heif_error heif_image_crop(struct heif_image* img,
 // This function returns the number of bits used for storage of each pixel.
 // Especially for HDR images, this is probably not what you want. Have a look at
 // heif_image_get_bits_per_pixel_range() instead.
-LIBHEIF_API
-int heif_image_get_bits_per_pixel(const struct heif_image*, enum heif_channel channel);
-
+//LIBHEIF_API
+int heif_image_get_bits_per_pixel(const struct heif_image*,enum heif_channel channel);
 
 // Get the number of bits per pixel in the given image channel. This function returns
 // the number of bits used for representing the pixel value, which might be smaller
@@ -993,22 +838,22 @@ int heif_image_get_bits_per_pixel(const struct heif_image*, enum heif_channel ch
 // For example, in 12bit HDR images, this function returns '12', while still 16 bits
 // are reserved for storage. For interleaved RGBA with 12 bit, this function also returns
 // '12', not '48' or '64' (heif_image_get_bits_per_pixel returns 64 in this case).
-LIBHEIF_API
-int heif_image_get_bits_per_pixel_range(const struct heif_image*, enum heif_channel channel);
+//LIBHEIF_API
+int heif_image_get_bits_per_pixel_range(const struct heif_image*,enum heif_channel channel);
 
-LIBHEIF_API
+//LIBHEIF_API
 int heif_image_has_channel(const struct heif_image*, enum heif_channel channel);
 
 // Get a pointer to the actual pixel data.
 // The 'out_stride' is returned as "bytes per line".
 // When out_stride is NULL, no value will be written.
 // Returns NULL if a non-existing channel was given.
-LIBHEIF_API
+//LIBHEIF_API
 const uint8_t* heif_image_get_plane_readonly(const struct heif_image*,
                                              enum heif_channel channel,
                                              int* out_stride);
 
-LIBHEIF_API
+//LIBHEIF_API
 uint8_t* heif_image_get_plane(struct heif_image*,
                               enum heif_channel channel,
                               int* out_stride);
@@ -1017,7 +862,7 @@ uint8_t* heif_image_get_plane(struct heif_image*,
 struct heif_scaling_options;
 
 // Currently, heif_scaling_options is not defined yet. Pass a NULL pointer.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_scale_image(const struct heif_image* input,
                                          struct heif_image** output,
                                          int width, int height,
@@ -1025,26 +870,25 @@ struct heif_error heif_image_scale_image(const struct heif_image* input,
 
 // The color profile is not attached to the image handle because we might need it
 // for color space transform and encoding.
-LIBHEIF_API
+//LIBHEIF_API
 struct heif_error heif_image_set_raw_color_profile(struct heif_image* image,
                                                    const char* profile_type_fourcc_string,
                                                    const void* profile_data,
                                                    const size_t profile_size);
 
-LIBHEIF_API
+//IBHEIF_API
 struct heif_error heif_image_set_nclx_color_profile(struct heif_image* image,
                                                     const struct heif_color_profile_nclx* color_profile);
-
 
 // TODO: this function does not make any sense yet, since we currently cannot modify existing HEIF files.
 //LIBHEIF_API
 //void heif_image_remove_color_profile(struct heif_image* image);
 
 // Release heif_image.
-LIBHEIF_API
+//LIBHEIF_API
 void heif_image_release(const struct heif_image*);
 
-
+/*
 // ====================================================================================================
 //  Encoding API
 
@@ -1052,16 +896,15 @@ LIBHEIF_API
 struct heif_error heif_context_write_to_file(struct heif_context*,
                                              const char* filename);
 
-struct heif_writer
-{
+struct heif_writer {
   // API version supported by this writer
   int writer_api_version;
 
   // --- version 1 functions ---
-  struct heif_error (* write)(struct heif_context* ctx, // TODO: why do we need this parameter?
-                              const void* data,
-                              size_t size,
-                              void* userdata);
+  struct heif_error (*write)(struct heif_context* ctx, // TODO: why do we need this parameter?
+                             const void* data,
+                             size_t size,
+                             void* userdata);
 };
 
 LIBHEIF_API
@@ -1109,13 +952,14 @@ enum heif_compression_format
 heif_encoder_descriptor_get_compression_format(const struct heif_encoder_descriptor*);
 
 LIBHEIF_API
-int heif_encoder_descriptor_supports_lossy_compression(const struct heif_encoder_descriptor*);
+int heif_encoder_descriptor_supportes_lossy_compression(const struct heif_encoder_descriptor*);
 
 LIBHEIF_API
-int heif_encoder_descriptor_supports_lossless_compression(const struct heif_encoder_descriptor*);
+int heif_encoder_descriptor_supportes_lossless_compression(const struct heif_encoder_descriptor*);
 
 
 // Get an encoder instance that can be used to actually encode images from a descriptor.
+// TODO: why do we need the context here? I think we should remove this. You may pass a NULL context.
 LIBHEIF_API
 struct heif_error heif_context_get_encoder(struct heif_context* context,
                                            const struct heif_encoder_descriptor*,
@@ -1135,6 +979,7 @@ int heif_have_encoder_for_format(enum heif_compression_format format);
 
 // Get an encoder for the given compression format. If there are several encoder plugins
 // for this format, the encoder with the highest plugin priority will be returned.
+// TODO: why do we need the context here? I think we should remove this. You may pass a NULL context.
 LIBHEIF_API
 struct heif_error heif_context_get_encoder_for_format(struct heif_context* context,
                                                       enum heif_compression_format format,
@@ -1175,15 +1020,14 @@ struct heif_error heif_encoder_set_logging_level(struct heif_encoder*, int level
 // Each encoder may define its own, additional set of parameters.
 // You do not have to free the returned list.
 LIBHEIF_API
-const struct heif_encoder_parameter* const* heif_encoder_list_parameters(struct heif_encoder*);
+const struct heif_encoder_parameter*const* heif_encoder_list_parameters(struct heif_encoder*);
 
 // Return the parameter name.
 LIBHEIF_API
 const char* heif_encoder_parameter_get_name(const struct heif_encoder_parameter*);
 
 
-enum heif_encoder_parameter_type
-{
+enum heif_encoder_parameter_type {
   heif_encoder_parameter_type_integer = 1,
   heif_encoder_parameter_type_boolean = 2,
   heif_encoder_parameter_type_string = 3
@@ -1193,24 +1037,14 @@ enum heif_encoder_parameter_type
 LIBHEIF_API
 enum heif_encoder_parameter_type heif_encoder_parameter_get_type(const struct heif_encoder_parameter*);
 
-// DEPRECATED. Use heif_encoder_parameter_get_valid_integer_values() instead.
 LIBHEIF_API
 struct heif_error heif_encoder_parameter_get_valid_integer_range(const struct heif_encoder_parameter*,
                                                                  int* have_minimum_maximum,
                                                                  int* minimum, int* maximum);
 
-// If integer is limited by a range, have_minimum and/or have_maximum will be != 0 and *minimum, *maximum is set.
-// If integer is limited by a fixed set of values, *num_valid_values will be >0 and *out_integer_array is set.
-LIBHEIF_API
-struct heif_error heif_encoder_parameter_get_valid_integer_values(const struct heif_encoder_parameter*,
-                                                                  int* have_minimum, int* have_maximum,
-                                                                  int* minimum, int* maximum,
-                                                                  int* num_valid_values,
-                                                                  const int** out_integer_array);
-
 LIBHEIF_API
 struct heif_error heif_encoder_parameter_get_valid_string_values(const struct heif_encoder_parameter*,
-                                                                 const char* const** out_stringarray);
+                                                                 const char*const** out_stringarray);
 
 
 LIBHEIF_API
@@ -1254,15 +1088,7 @@ struct heif_error heif_encoder_get_parameter_string(struct heif_encoder*,
 LIBHEIF_API
 struct heif_error heif_encoder_parameter_string_valid_values(struct heif_encoder*,
                                                              const char* parameter_name,
-                                                             const char* const** out_stringarray);
-
-LIBHEIF_API
-struct heif_error heif_encoder_parameter_integer_valid_values(struct heif_encoder*,
-                                                              const char* parameter_name,
-                                                              int* have_minimum, int* have_maximum,
-                                                              int* minimum, int* maximum,
-                                                              int* num_valid_values,
-                                                              const int** out_integer_array);
+                                                             const char*const** out_stringarray);
 
 // Set a parameter of any type to the string value.
 // Integer values are parsed from the string.
@@ -1291,32 +1117,13 @@ int heif_encoder_has_default(struct heif_encoder*,
                              const char* parameter_name);
 
 
-struct heif_encoding_options
-{
+
+struct heif_encoding_options {
   uint8_t version;
 
   // version 1 options
 
   uint8_t save_alpha_channel; // default: true
-
-  // version 2 options
-
-  // Crops heif images with a grid wrapper instead of a 'clap' transform.
-  // Results in slightly larger file size.
-  // Default: on.
-  uint8_t macOS_compatibility_workaround;
-
-  // version 3 options
-
-  uint8_t save_two_colr_boxes_when_ICC_and_nclx_available; // default: false
-
-  // version 4 options
-
-  // Set this to the NCLX parameters to be used in the output image or set to NULL
-  // when the same parameters as in the input image should be used.
-  struct heif_color_profile_nclx* output_nclx_profile;
-
-  uint8_t macOS_compatibility_workaround_no_nclx_profile;
 };
 
 LIBHEIF_API
@@ -1407,13 +1214,6 @@ struct heif_error heif_image_add_plane(struct heif_image* image,
                                        enum heif_channel channel,
                                        int width, int height, int bit_depth);
 
-// Signal that the image is premultiplied by the alpha pixel values.
-LIBHEIF_API
-void heif_image_set_premultiplied_alpha(struct heif_image* image,
-                                        int is_premultiplied_alpha);
-
-LIBHEIF_API
-int heif_image_is_premultiplied_alpha(struct heif_image* image);
 
 
 
@@ -1432,18 +1232,11 @@ struct heif_error heif_register_decoder_plugin(const struct heif_decoder_plugin*
 LIBHEIF_API
 struct heif_error heif_register_encoder_plugin(const struct heif_encoder_plugin*);
 
-
-
-// DEPRECATED, typo in function name
-LIBHEIF_API
-int heif_encoder_descriptor_supportes_lossy_compression(const struct heif_encoder_descriptor*);
-
-// DEPRECATED, typo in function name
-LIBHEIF_API
-int heif_encoder_descriptor_supportes_lossless_compression(const struct heif_encoder_descriptor*);
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif
+
+*/
+

--- a/pyheif/constants.py
+++ b/pyheif/constants.py
@@ -35,7 +35,7 @@ def encode_fourcc(fourcc):
 
 heif_color_profile_type_not_present = 0
 heif_color_profile_type_nclx = encode_fourcc("nclx")
-heif_color_profile_type_rICC = encode_fourcc("rICCC")
+heif_color_profile_type_rICC = encode_fourcc("rICC")
 heif_color_profile_type_prof = encode_fourcc("prof")
 
 heif_filetype_no = 0

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -207,7 +207,9 @@ def _read_color_profile(handle):
         color_profile["type"] = "nclx"
         data_length = _libheif_cffi.ffi.sizeof("struct heif_color_profile_nclx")
         p_p_data = _libheif_cffi.ffi.new("struct heif_color_profile_nclx * *")
-        error = _libheif_cffi.lib.heif_image_handle_get_nclx_color_profile(handle, p_p_data)
+        error = _libheif_cffi.lib.heif_image_handle_get_nclx_color_profile(
+            handle, p_p_data
+        )
         p_data = p_p_data[0]
 
     else:
@@ -215,9 +217,13 @@ def _read_color_profile(handle):
             color_profile["type"] = "rICC"
         elif profile_type == _constants.heif_color_profile_type_prof:
             color_profile["type"] = "prof"
-        data_length = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile_size(handle)
+        data_length = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile_size(
+            handle
+        )
         p_data = _libheif_cffi.ffi.new("char[]", data_length)
-        error = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile(handle, p_data)
+        error = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile(
+            handle, p_data
+        )
 
     if error.code != 0:
         raise _error.HeifError(

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -205,20 +205,19 @@ def _read_color_profile(handle):
     color_profile = {"type": "unknown", "data": None}
     if profile_type == _constants.heif_color_profile_type_nclx:
         color_profile["type"] = "nclx"
-        p_data = _libheif_cffi.ffi.new("struct heif_color_profile_nclx * *")
-        error = _libheif_cffi.lib.heif_image_handle_get_nclx_color_profile(handle, p_data)
-        data_buffer = _libheif_cffi.ffi.buffer(p_data)
+        data_length = _libheif_cffi.ffi.sizeof("struct heif_color_profile_nclx")
+        p_p_data = _libheif_cffi.ffi.new("struct heif_color_profile_nclx * *")
+        error = _libheif_cffi.lib.heif_image_handle_get_nclx_color_profile(handle, p_p_data)
+        p_data = p_p_data[0]
 
     else:
         if profile_type == _constants.heif_color_profile_type_rICC:
             color_profile["type"] = "rICC"
         elif profile_type == _constants.heif_color_profile_type_prof:
             color_profile["type"] = "prof"
-
         data_length = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile_size(handle)
         p_data = _libheif_cffi.ffi.new("char[]", data_length)
         error = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile(handle, p_data)
-        data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)
 
     if error.code != 0:
         raise _error.HeifError(
@@ -226,7 +225,7 @@ def _read_color_profile(handle):
             subcode=error.subcode,
             message=_libheif_cffi.ffi.string(error.message).decode(),
         )
-
+    data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)
     data = bytes(data_buffer)
     color_profile["data"] = data
 


### PR DESCRIPTION
Thanks for paying attention to nclx profile failing with libheif 1.10 and above. Unfortunately the fix doesn't work as expected since it creates profile from pointer to another pointer. I didn't create my own Pull Request to the upstream, instead you can merge this in your branch and https://github.com/carsales/pyheif/pull/50 will be updated.

I've checked this code with both libheif 1.9.1 and current master, it works well.